### PR TITLE
Call success, error and complete handlers in the right order

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,29 +121,7 @@ AjaxLimited.prototype.ajax = function() {
   var bucket = this.getBucketFor(args);
   return bucket.removeTokensAsync(1).then(function() {
     var settings = _.isString(args[0]) ? args[1] : args[0];
-
-    var success;
-    var error;
-
-    if(settings != null) {
-      if(settings.success != null) {
-        success = settings.success;
-        delete settings.success;
-      }
-
-      if(settings.error != null) {
-        error = settings.error;
-        delete settings.error;
-      }
-    }
-
-    var ret = Promise.resolve(_this.originalAjax.apply(_this.targets[0], args));
-
-    if(success != null || error != null) {
-      return ret.then(success, error);
-    }
-
-    return ret;
+    return Promise.resolve(_this.originalAjax.apply(_this.targets[0], args));
   });
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -199,8 +199,8 @@ describe('AjaxLimited([options])', function() {
         this.stats.requests++;
         var method = (options.type || options.method || 'get').toLowerCase();
         this.stats[method + 'Requests']++;
-        if(typeof options.success === 'function') options.success()
-        if(typeof options.complete === 'function') options.complete()
+        if(typeof options.success === 'function') options.success();
+        if(typeof options.complete === 'function') options.complete();
         return Promise.resolve({});
       }, true);
 
@@ -266,6 +266,7 @@ describe('AjaxLimited([options])', function() {
           return Promise.all(ps);
         });
       });
+
       it('success, and complete handlers are called in order', function() {
         var success = sinon.spy();
         var complete = sinon.spy(function() {
@@ -281,7 +282,6 @@ describe('AjaxLimited([options])', function() {
     });
 
     describe('when AJAX is unsuccessful', function() {
-
       afterEach(function() {
         this.ajaxLimited.restore();
       });
@@ -292,10 +292,9 @@ describe('AjaxLimited([options])', function() {
           url = options.url;
         }
 
-        if(typeof options.error === 'function') options.error()
-        if(typeof options.complete === 'function') options.complete()
+        if(typeof options.error === 'function') options.error();
+        if(typeof options.complete === 'function') options.complete();
         return Promise.reject(new Error("AJAX Failed"));
-
       }, true);
 
       it('error, and complete handlers are called in order', function() {
@@ -303,6 +302,7 @@ describe('AjaxLimited([options])', function() {
         var complete = sinon.spy(function() {
           error.calledOnce.should.be.true;
         });
+
         return $.ajax('http://localhost:3000', {
           error: error,
           complete: complete
@@ -312,7 +312,6 @@ describe('AjaxLimited([options])', function() {
           complete.calledOnce.should.be.true;
         });
       });
-
     });
   });
 });


### PR DESCRIPTION
I didn't see a reason why the success and error handles were wrapped in the first place so I simply removed the wrapping, letting the problem fix itself.

The original original promise should still behave the same way.